### PR TITLE
Fixed some clang warnings

### DIFF
--- a/binson.cpp
+++ b/binson.cpp
@@ -9,16 +9,18 @@ using namespace std;
 
 #define IF_RUNTIME_ERROR(x, msg) if (!(x)) throw std::runtime_error(msg)
 
-const std::array<std::string, 8> BinsonValue::typeToString =
+const std::array<std::string, 8> BinsonValue::typeToString
 {
-    "noneType",
-    "boolType",
-    "intType",
-    "doubleType",
-    "stringType",
-    "binaryType",
-    "objectType",
-    "arrayType",
+    {
+        "noneType",
+        "boolType",
+        "intType",
+        "doubleType",
+        "stringType",
+        "binaryType",
+        "objectType",
+        "arrayType"
+    }
 };
 
 Binson & Binson::put(const std::string &key, const BinsonValue &v)
@@ -36,7 +38,7 @@ Binson & Binson::put(const std::string &key, Binson o)
 Binson & Binson::put(const string &key, const uint8_t *data, size_t size)
 {
     vector<uint8_t> v(data, data + size);
-    m_items[key] = move(BinsonValue(move(v)));
+    m_items[key] = BinsonValue(v);
     return *this;
 }
 


### PR DESCRIPTION
When building with clang there where some warnings. They are now fixed. 


```
cmake  -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/andreas/src/binson-c-light
andreas@andreas-VirtualBox:~/src/binson-c-light$ make
[  0%] Built target binson_parser
[  0%] Built target r_fuzz_goinoutarr
[  1%] Built target r_fuzz_parser_verify
[  1%] Built target binson_writer
Scanning dependencies of target binson_class
[  1%] Building CXX object CMakeFiles/binson_class.dir/binson.cpp.o
/home/andreas/src/binson-c-light/binson.cpp:14:5: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    "noneType",
    ^~~~~~~~~~~
/home/andreas/src/binson-c-light/binson.cpp:39:20: error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
    m_items[key] = move(BinsonValue(move(v)));
                   ^
/home/andreas/src/binson-c-light/binson.cpp:39:20: note: remove std::move call here
    m_items[key] = move(BinsonValue(move(v)));
                   ^~~~~                    ~
2 errors generated.
```